### PR TITLE
Fix for divide by zero error & Readme update.

### DIFF
--- a/MORAD_Drums.ino
+++ b/MORAD_Drums.ino
@@ -66,8 +66,10 @@ HardwareSerial MIDISerial(2);
 MIDI_CREATE_CUSTOM_INSTANCE(HardwareSerial, MIDISerial, MIDI, SerialMIDISettings);
 
 // create OLED display device
+#define SCREEN_WIDTH 128 // OLED display width, in pixels
+#define SCREEN_HEIGHT 32 // OLED display height, in pixels
 #define OLED_RESET -1  // unused port - to keep the compiler happy
-Adafruit_SSD1306 display(OLED_RESET);
+Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 
 // encoder 
 ClickEncoder clickEncoder(ENC_A,ENC_B,ENC_SW,4); // divide by 4 works best with my encoder

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This example shows how to play audio samples at 22khz on one of the DAC outputs.
 
 * Clickencoder (included in the sketch library directory)
 
+* MIDI Library https://github.com/FortySevenEffects/arduino_midi_library
+
 "wav2header" utility is included which will auto generate the required header files from 22 or 44khz .wav files. see resources/readme.md
 
 Compiled with Arduino 1.85 with ESP32 Arduino installed. Use "ESP32 DEV Module" as the board and "NO OTA (Large App)" as the partition scheme. This partition scheme has a limit of 2Mb for the app size. I think its possible to create a partition scheme to use most of the 4Mb of flash but I have not tried it. 


### PR DESCRIPTION
Fix for the divide by zero error caused when initializing display. https://github.com/rheslip/Motivation-Radio-Drum-Machine/issues/1#issue-542720307

Also updated Readme to reflect that you also need the MIDI Library installed.